### PR TITLE
New allure js commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Allure reporter for Mocha
 Assume that you have [mocha](http://mochajs.org/) installed, install reporter via npm:
 
 ```
+npm install allure-js-commons
 npm install mocha-allure-reporter
 ```
 
 Then use it as any other mocha reporter
 
 ```
-mocha --reporter mocha-allure-reporter
+mocha --reporter mocha-allure-reporter -r 'allure-js-commons/runtime'
 ```
 
 After tests you get raw tests result into `allure-results` directory. 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function AllureReporter(runner, opts) {
         allure = new Allure(options);
 
     runner.on('start', function() {
-        global.allure = new AllureRuntime(allure);
+        global.allure = allure;
     });
 
     runner.on('suite', function (suite) {

--- a/index.js
+++ b/index.js
@@ -34,13 +34,26 @@ function AllureReporter(runner, opts) {
     });
 
     runner.on('pass', function(test) {
+        addStepsInfo(test.parent);
         allure.endCase(test.parent.fullTitle(), test.title, 'passed');
     });
 
     runner.on('fail', function(test, err) {
         var status = err.name === 'AssertionError' ? 'failed' : 'broken';
+        addStepsInfo(test.parent);
         allure.endCase(test.parent.fullTitle(), test.title, status, err);
     });
+
+    function addStepsInfo(suite) {
+        var publishSubsteps = function(step) {
+            allure.startStep(suite, step.name, step.start);
+            step.steps.forEach(publishSubsteps, this);
+            allure.endStep(suite, step.name, step.status, step.stop)
+        };
+
+        global.allure.report.steps.forEach(publishSubsteps);
+        global.allure.flushReport();
+    }
 }
 
 AllureReporter.prototype.__proto__ = Base.prototype;

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ function AllureReporter(runner, opts) {
 
     runner.on('fail', function(test, err) {
         var status = err.name === 'AssertionError' ? 'failed' : 'broken';
+        if(global.onError) {
+            global.onError();
+        }
         addExtraInfo(test.parent.fullTitle());
         allure.endCase(test.parent.fullTitle(), test.title, status, err);
     });

--- a/index.js
+++ b/index.js
@@ -20,28 +20,28 @@ function AllureReporter(runner, opts) {
             this.parent = parent;
             global.allure = this.allure;
         },
-        currentSuite = null;
+        currentMochaSuite = null;
 
     runner.on('suite', function (suite) {
-        currentSuite = new Suite(currentSuite);
-        currentSuite.allure.startSuite(suite.fullTitle());
+        currentMochaSuite = new Suite(currentMochaSuite);
+        currentMochaSuite.allure.startSuite(suite.fullTitle());
     });
 
     runner.on('suite end', function (suite) {
-        currentSuite.allure.endSuite(suite.fullTitle());
-        currentSuite = currentSuite.parent;
+        currentMochaSuite.allure.endSuite();
+        currentMochaSuite = currentMochaSuite.parent;
     });
 
     runner.on('test', function(test) {
-        currentSuite.allure.startCase(test.title);
+        currentMochaSuite.allure.startCase(test.title);
     });
 
     runner.on('pending', function(test) {
-        currentSuite.allure.pendingCase(test.title);
+        currentMochaSuite.allure.pendingCase(test.title);
     });
 
     runner.on('pass', function() {
-        currentSuite.allure.endCase('passed');
+        currentMochaSuite.allure.endCase('passed');
     });
 
     runner.on('fail', function(test, err) {
@@ -49,7 +49,7 @@ function AllureReporter(runner, opts) {
         if(global.onError) {
             global.onError();
         }
-        currentSuite.allure.endCase(status, err);
+        currentMochaSuite.allure.endCase(status, err);
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var Base = require('mocha').reporters.Base,
-    Allure = require('allure-js-commons'),
-    AllureRuntime = require('allure-js-commons/runtime');
+    Allure = require('allure-js-commons');
 
 
 module.exports = AllureReporter;

--- a/index.js
+++ b/index.js
@@ -34,13 +34,13 @@ function AllureReporter(runner, opts) {
     });
 
     runner.on('pass', function(test) {
-        addStepsInfo(test.parent);
+        addStepsInfo(test.parent.fullTitle());
         allure.endCase(test.parent.fullTitle(), test.title, 'passed');
     });
 
     runner.on('fail', function(test, err) {
         var status = err.name === 'AssertionError' ? 'failed' : 'broken';
-        addStepsInfo(test.parent);
+        addStepsInfo(test.parent.fullTitle());
         allure.endCase(test.parent.fullTitle(), test.title, status, err);
     });
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function AllureReporter(runner, opts) {
 
         global.allure.report.steps.forEach(publishSubsteps);
         global.allure.report.attachments.forEach(function(attachment) {
-            allure.addAttachment(suite, attachment.name, attachment.buffer);
+            allure.addAttachment(suite, attachment.name, attachment.buffer, attachment.type);
         });
         global.allure.flushReport();
     }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function AllureReporter(runner, opts) {
         Suite = function(parent) {
             this.allure = new Allure(options);
             this.parent = parent;
-            global.allure = this.allure;
+            global.allure.setAllure(this.allure);
         },
         currentMochaSuite = null;
 

--- a/index.js
+++ b/index.js
@@ -34,24 +34,27 @@ function AllureReporter(runner, opts) {
     });
 
     runner.on('pass', function(test) {
-        addStepsInfo(test.parent.fullTitle());
+        addExtraInfo(test.parent.fullTitle());
         allure.endCase(test.parent.fullTitle(), test.title, 'passed');
     });
 
     runner.on('fail', function(test, err) {
         var status = err.name === 'AssertionError' ? 'failed' : 'broken';
-        addStepsInfo(test.parent.fullTitle());
+        addExtraInfo(test.parent.fullTitle());
         allure.endCase(test.parent.fullTitle(), test.title, status, err);
     });
 
-    function addStepsInfo(suite) {
+    function addExtraInfo(suite) {
         var publishSubsteps = function(step) {
             allure.startStep(suite, step.name, step.start);
             step.steps.forEach(publishSubsteps, this);
-            allure.endStep(suite, step.name, step.status, step.stop)
+            allure.endStep(suite, step.name, step.status, step.stop);
         };
 
         global.allure.report.steps.forEach(publishSubsteps);
+        global.allure.report.attachments.forEach(function(attachment) {
+            allure.addAttachment(suite, attachment.name, attachment.buffer);
+        });
         global.allure.flushReport();
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git#singlesuite",
+    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git#singlesuite2",
     "mocha": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git#singlesuite2",
+    "allure-js-commons": "git+https://github.com/allure-framework/allure-js-commons.git",
     "mocha": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git",
+    "allure-js-commons": "git+https://github.com/allure-framework/allure-js-commons.git",
     "mocha": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git",
+    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git#singlesuite",
     "mocha": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "allure-js-commons": "git+https://github.com/allure-framework/allure-js-commons.git",
+    "allure-js-commons": "git+https://github.com/d0lfin/allure-js-commons.git",
     "mocha": "^2.2.4"
   }
 }


### PR DESCRIPTION
Теперь для каждого сьюта моки свой аллюр, который при запуске сьюта пробрасывается в глобальную область видимости.
Заинжектить основной аллюр в рантайм аллюр в конструкторе не получится, т.к. отчет подключается после выполнения первого describe. И соответственно объекты создают степы еще до подключения репортера.
Так же не получится получить context. В репортере не доступно нужное событие. Там только события про тесты и сьюты.
Чтобы рантайм оказался в глобальной области видимости, тесты надо запускать вот так ```mocha --reporter mocha-allure-reporter -r 'allure-js-commons/runtime'```