### PR TITLE
fix error with lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = AllureReporter;
  */
 function AllureReporter(runner, opts) {
     Base.call(this, runner);
-    allureReporter.setOptions(opts.reporterOptions ? opts.reporterOptions : {});
+    allureReporter.setOptions(opts.reporterOptions || {});
 
     runner.on('suite', function (suite) {
         allureReporter.startSuite(suite.fullTitle());

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = AllureReporter;
  */
 function AllureReporter(runner, opts) {
     Base.call(this, runner);
-    allureReporter.setOptions(opts.reporterOptions);
+    allureReporter.setOptions(opts.reporterOptions ? opts.reporterOptions : {});
 
     runner.on('suite', function (suite) {
         allureReporter.startSuite(suite.fullTitle());


### PR DESCRIPTION
If you try to use _.defaults for undefined object, method will returns the undefined object without 'targetDir' property. And then it will throw error, when library try to save tests result. By default the property opts.reporterOptions is undefined.