### PR TITLE
Accounting for error's in the before hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ function AllureReporter(runner, opts) {
     });
 
     runner.on("fail", function(test, err) {
+        if(!allureReporter.getCurrentTest()) {
+            allureReporter.startCase(test.title);
+        }
         var status = err.name === "AssertionError" ? "failed" : "broken";
         if(global.onError) {
             global.onError(err);

--- a/test/fixtures/before_all.spec.js
+++ b/test/fixtures/before_all.spec.js
@@ -1,0 +1,16 @@
+describe("Before all tests", function() {
+
+    describe("broken before", function() {
+        before(function() {
+            throw new Error("you broke the before hook");
+        });
+
+        it("a test", function() {});
+    })
+
+    describe("before not broken", function() {
+        before(function() {});
+        it("a test", function() {});
+    })
+
+});

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -8,39 +8,53 @@ var path = require('path'),
 
 chai.use(sinonChai);
 
-mockery.enable({
-    warnOnUnregistered: false,
-    useCleanCache: true
-});
-
-var allureMock = sinon.stub({
-        setOptions: function() {},
-        startSuite: function() {},
-        endSuite: function() {},
-        getSuite: function() {},
-        startCase: function() {},
-        endCase: function() {},
-        pendingCase: function() {}
-    }),
-    runtimeMock = sinon.stub({
-        createStep: function() {},
-        createAttachment: function() {},
-        addLabel: function() {}
-    });
-runtimeMock.createStep.returns(function() {});
-runtimeMock.createAttachment.returns(function() {});
-
-
-mockery.registerMock('allure-js-commons', function() {
-    return allureMock;
-});
-mockery.registerMock('allure-js-commons/runtime', function() {
-    return runtimeMock;
-});
-
-
-var reporter = require('../../');
 describe("Allure reporter", function() {
+    var allureMock;
+    var runtimeMock;
+    var sandbox;
+    var reporter;
+
+    beforeEach(function(){
+        sandbox = sinon.sandbox.create();
+        mockery.enable({
+            warnOnUnregistered: false,
+            warnOnReplace: false,
+            useCleanCache: true
+        });
+        allureMock = sandbox.stub({
+                getCurrentTest: function(){},
+                setOptions: function() {},
+                startSuite: function() {},
+                endSuite: function() {},
+                getSuite: function() {},
+                startCase: function() {},
+                endCase: function() {},
+                pendingCase: function() {}
+            })
+        allureMock.getCurrentTest.returns('a test');
+        runtimeMock = sandbox.stub({
+                createStep: function() {},
+                createAttachment: function() {},
+                addLabel: function() {}
+            });
+        runtimeMock.createStep.returns(function() {});
+        runtimeMock.createAttachment.returns(function() {});
+
+
+        mockery.registerMock('allure-js-commons', function() {
+            return allureMock;
+        });
+        mockery.registerMock('allure-js-commons/runtime', function() {
+            return runtimeMock;
+        });
+        reporter = require('../../');
+    })
+
+    afterEach(function(){
+        sandbox.restore();
+        mockery.disable();
+    })
+
     it("should report test results", function(done) {
         var mocha = new Mocha({
             reporter: reporter
@@ -64,6 +78,29 @@ describe("Allure reporter", function() {
 
             expect(allureMock.pendingCase).calledOnce;
             expect(allureMock.pendingCase.firstCall).calledWith('pending test');
+            done();
+        })
+    });
+    it("should report test results if there is a failure in a before test hook", function(done) {
+        allureMock.getCurrentTest.onFirstCall().returns(undefined);
+        allureMock.getCurrentTest.onSecondCall().returns('a test');
+        var mocha = new Mocha({
+            reporter: reporter
+        });
+        mocha.addFile(path.join(__dirname, '../fixtures/before_all.spec.js'));
+        mocha.run(function(status) {
+            expect(allureMock.startSuite).callCount(4);
+            expect(allureMock.startSuite.secondCall).calledWithExactly('Before all tests');
+            expect(allureMock.startSuite.thirdCall).calledWithExactly('Before all tests broken before');
+            expect(allureMock.startSuite.lastCall).calledWithExactly('Before all tests before not broken');
+            expect(allureMock.endSuite).callCount(4);
+
+            expect(allureMock.startCase.firstCall).calledAfter(allureMock.startSuite.secondCall);
+            expect(allureMock.startCase.firstCall).calledWithExactly('"before all" hook');
+            expect(allureMock.endCase.firstCall).calledWith('broken', sinon.match.instanceOf(Error));
+
+            expect(allureMock.startCase.secondCall).calledWithExactly('a test');
+            expect(allureMock.endCase).to.have.been.calledTwice;
 
             done();
         })

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -102,6 +102,7 @@ describe("Allure reporter", function() {
             expect(allureMock.startCase.secondCall).calledWithExactly('a test');
             expect(allureMock.endCase).to.have.been.calledTwice;
 
+            expect(status).to.be.equal(1);
             done();
         })
     });


### PR DESCRIPTION
We are using this library with the jenkins plugin in order to have a nice look to our test results. I found this problem when one of our builds passed despite the environment not working properly. This caused all of the before all hooks to fail, and the tests still passed.

I added in a step before you end a failed case to check whether or not a step exists, and if it does not, add the current one as the current step. This makes it so that when there is a failure in a before all hook, it uses the text '"Before All" hook' as the test case.

Let me know if this is something you'd like to add in or if you want this tackled in another way. Also let me know if this is something that you don't want in it. 

Thanks. 

Summary:

Why:

* previously, tests seemed to immediately exit with no status code (Defaulted to 0) when there was an error in a before block
* this was hapening because of an unhandled error where there was no current step when a before hook failed

This change addresses the need by:

* I added validation where if there was no current test, it would use the title of the one that failed (which happens to explicitly say the before hook)
