### PR TITLE
Do not start a test case when mocha retries a failed test.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function AllureReporter(runner, opts) {
     });
 
     runner.on("test", function(test) {
-        allureReporter.startCase(test.title);
+        if (!test.currentRetry()) {
+          allureReporter.startCase(test.title);
+        }
     });
 
     runner.on("pending", function(test) {

--- a/test/fixtures/retries.spec.js
+++ b/test/fixtures/retries.spec.js
@@ -1,0 +1,23 @@
+"use strict";
+var chai = require("chai");
+var expect = chai.expect;
+chai.use(require("dirty-chai"));
+
+describe('A mocha suite with "retries" option', function() {
+    var counter = 0;
+    this.retries(3);
+
+    it("passing test", function() {
+        expect(true).to.be.true();
+    });
+
+    it("failed test", function() {
+        expect(false).to.be.true();
+    });
+
+    it("passing test after retry", function() {
+        counter++;
+        expect(counter).to.equal(2);
+    });
+});
+

--- a/test/unit/reporter.spec.js
+++ b/test/unit/reporter.spec.js
@@ -106,4 +106,28 @@ describe("Allure reporter", function() {
             done();
         })
     });
+    it("should report test results with 'retries' option", function(done) {
+        var mocha = new Mocha({
+            reporter: reporter
+        });
+        mocha.addFile(path.join(__dirname, '../fixtures/retries.spec.js'));
+        mocha.run(function() {
+            expect(allureMock.startSuite).callCount(2);
+            expect(allureMock.startSuite.secondCall).calledWithExactly('A mocha suite with "retries" option');
+            expect(allureMock.endSuite).callCount(2);
+            expect(allureMock.startCase).callCount(3);
+            expect(allureMock.endCase).callCount(3);
+
+            expect(allureMock.startCase.firstCall).calledWithExactly('passing test');
+            expect(allureMock.endCase.firstCall).calledWith('passed');
+
+            expect(allureMock.startCase.secondCall).calledWithExactly('failed test');
+            expect(allureMock.endCase.secondCall).calledWith('failed', sinon.match.instanceOf(Error));
+
+            expect(allureMock.startCase.thirdCall).calledWithExactly('passing test after retry');
+            expect(allureMock.endCase.thirdCall).calledWith('passed');
+
+            done();
+        })
+    });
 });


### PR DESCRIPTION
I did some investigations and found mocha behaviour to be correct. When performing a retry it clones a test case, which causes *test* event to be emited each time, but *pass*/*fail* events are emited only once when either retry count ended or test passed. 
So my idea is to prevent creating a test case in reporter for each retry except the first one.

There is a problem I've met with adding test properties in hooks, the final report has the same property added in the number of retries.
